### PR TITLE
Small YCB detection model

### DIFF
--- a/perception_models/detectors/ycb/classes_ycb_small.yaml
+++ b/perception_models/detectors/ycb/classes_ycb_small.yaml
@@ -1,0 +1,16 @@
+0: __background
+1: 001_chips_can
+2: 003_cracker_box
+3: 004_sugar_box
+4: 005_tomato_soup_can
+5: 006_mustard_bottle
+6: 011_banana
+7: 012_strawberry
+8: 013_apple
+9: 017_orange
+10: 019_pitcher_base
+11: 023_wine_glass
+12: 025_mug
+13: 055_baseball
+14: 056_tennis_ball
+15: 057_racquetball

--- a/perception_models/detectors/ycb/ycb_small.pt
+++ b/perception_models/detectors/ycb/ycb_small.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:865a73ca825e8c2d11d234f00e504e4445b7e8c89bd57e438c326ce02d42b2cc
+size 166016888


### PR DESCRIPTION
This PR adds a PyTorch-based [Faster R-CNN](https://pytorch.org/docs/stable/_modules/torchvision/models/detection/faster_rcnn.html) model for a small subset of the [YCB object set](https://www.ycbbenchmarks.com/object-set/). The model was trained with augmented data generated with the utilities in [dataset_interface](https://github.com/b-it-bots/dataset_interface).

The model is trained for 15 classes of the set: chips can, cracker box, sugar box, tomato soup can, mustard bottle, banana, strawberry, apple, orange, pitcher base, wine glass, mug, baseball, tennis ball, and racquetball. I have not evaluated the model explicitly, but I have used it in several experiments with the HSR; with the exception of the wine glass, the other objects are detected generally reliably.